### PR TITLE
Falta de acento diacrítico en basico en la Introducción

### DIFF
--- a/informe-correcciones.md
+++ b/informe-correcciones.md
@@ -12,3 +12,11 @@ __Introduccion__
 - Herramienta utilizada: LenguageTool
 - Cambio realizado: Introduccion -> Introducción
 - Justificación: Falta de un signo diacrítico.
+
+Falta de acento diacrítico en basico en la Introducción
+
+__basico__
+
+- Herramienta utilizada: LenguageTool
+- Cambio realizado: basico -> básico
+- Justificación: Falta de un signo diacrítico.

--- a/informe-correcciones.md
+++ b/informe-correcciones.md
@@ -18,3 +18,9 @@ __basico__
 - Herramienta utilizada: LenguageTool
 - Cambio realizado: basico -> básico
 - Justificación: Falta de un signo diacrítico.
+
+__usuairo__
+
+- Herramienta utilizada: LenguageTool
+- Cambio realizado: usuairo -> usuario
+- Justificación: Corrección ortográfica.

--- a/informe-correcciones.md
+++ b/informe-correcciones.md
@@ -1,0 +1,16 @@
+# Informe de correcciones
+
+## Errores encontrados
+
+__Guion__
+- Herramienta utilizada: LenguageTool
+- Cambio realizado: Guion -> Guión
+- Justificación: Falta de un signo diacrítico
+
+Falta de acento diacrítico en Introduccion
+
+__Introduccion__
+
+- Herramienta utilizada: LenguageTool
+- Cambio realizado: Introduccion -> Introducción
+- Justificación: Falta de un signo diacrítico.

--- a/informe-correcciones.md
+++ b/informe-correcciones.md
@@ -13,8 +13,6 @@ __Introduccion__
 - Cambio realizado: Introduccion -> Introducción
 - Justificación: Falta de un signo diacrítico.
 
-Falta de acento diacrítico en basico en la Introducción
-
 __basico__
 
 - Herramienta utilizada: LenguageTool

--- a/informe-correcciones.md
+++ b/informe-correcciones.md
@@ -7,8 +7,6 @@ __Guion__
 - Cambio realizado: Guion -> Guión
 - Justificación: Falta de un signo diacrítico
 
-Falta de acento diacrítico en Introduccion
-
 __Introduccion__
 
 - Herramienta utilizada: LenguageTool

--- a/manual.md
+++ b/manual.md
@@ -2,7 +2,7 @@
 
 ## Introducción  
 
-Este manual describe el uso básico del Sistema de Gestion de Inventarios (SGI). El objetivo es guiar al **usuairo** en las funciones principales, como agregar productos, consultar **eccistencias** y generar reportes.  
+Este manual describe el uso básico del Sistema de Gestion de Inventarios (SGI). El objetivo es guiar al **usuarui** en las funciones principales, como agregar productos, consultar **eccistencias** y generar reportes.  
 El **SGI** es una aplicacion diseñada para pequeñas y medianas empresas. Se recomienda que cada **usuarios** lea cuidadosamente este manual antes de empezar a utilizar el sistema.  
 
 ---

--- a/manual.md
+++ b/manual.md
@@ -2,7 +2,7 @@
 
 ## Introducción  
 
-Este manual describe el uso basico del Sistema de Gestion de Inventarios (SGI). El objetivo es guiar al **usuairo** en las funciones principales, como agregar productos, consultar **eccistencias** y generar reportes.  
+Este manual describe el uso básico del Sistema de Gestion de Inventarios (SGI). El objetivo es guiar al **usuairo** en las funciones principales, como agregar productos, consultar **eccistencias** y generar reportes.  
 El **SGI** es una aplicacion diseñada para pequeñas y medianas empresas. Se recomienda que cada **usuarios** lea cuidadosamente este manual antes de empezar a utilizar el sistema.  
 
 ---

--- a/manual.md
+++ b/manual.md
@@ -1,6 +1,6 @@
 # Manual de Usuario – Sistema de Gestion de Inventarios
 
-## Introduccion  
+## Introducción  
 
 Este manual describe el uso basico del Sistema de Gestion de Inventarios (SGI). El objetivo es guiar al **usuairo** en las funciones principales, como agregar productos, consultar **eccistencias** y generar reportes.  
 El **SGI** es una aplicacion diseñada para pequeñas y medianas empresas. Se recomienda que cada **usuarios** lea cuidadosamente este manual antes de empezar a utilizar el sistema.  


### PR DESCRIPTION
- Herramienta utilizada: LenguageTool
- Cambio realizado: basico -> básico
- Justificación: Falta de un signo diacrítico.